### PR TITLE
[DOC] Fix supported Node.js version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compatibility
 
 * Ember.js v3.20 or above
 * Ember CLI v3.20 or above
-* Node.js v10 or above
+* Node.js v12 or above
 
 
 Installation


### PR DESCRIPTION
Match README.md with `engines` field of `package.json` as latter has valid value (per discussion in #6):

https://github.com/emberjs/ember-legacy-built-in-components/blob/4b315e304c34d87d4f73034fceb298bc31878359/package.json#L103-L105