### PR TITLE
Fix default value for `linkTitle` property

### DIFF
--- a/addon/components/link-to.ts
+++ b/addon/components/link-to.ts
@@ -416,7 +416,7 @@ const LinkComponent = EmberComponent.extend({
     @property linkTitle
     @private
   */
-  linkTitle: UNDEFINED,
+  linkTitle: undefined,
 
   /**
     By default this component will forward `href`, `title`, `rel`, `tabindex`, and `target`


### PR DESCRIPTION
`linkTitle` was assigned default value of `UNDEFINED` which is an object hence
some conditions could accidentally evaluate to truthy