### PR TITLE
Add back assertLinkToOrigin to components/link-to

### DIFF
--- a/addon/components/link-to.ts
+++ b/addon/components/link-to.ts
@@ -508,12 +508,7 @@ const LinkComponent = EmberComponent.extend({
   init() {
     this._super(...arguments);
 
-    assert(
-      'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
-        'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
-        'See https://ember-engines.com/docs/links for more info.',
-      !this._isEngine || this._engineMountPoint !== undefined
-    );
+    this.assertLinkToOrigin();
 
     // Map desired event name to invoke function
     let { eventName } = this;
@@ -525,6 +520,23 @@ const LinkComponent = EmberComponent.extend({
   _currentRouterState: alias('_routing.currentState'),
   _targetRouterState: alias('_routing.targetState'),
 
+  /**
+   * Method to assert that LinkTo is not used inside of a routeless engine. This method is
+   * overridden in ember-engines link-to-external component to just be a noop, since the
+   * link-to-external component extends the link-to component.
+   *
+   * @method assertLinkToOrigin
+   * @private
+   */
+  assertLinkToOrigin() {
+    assert(
+      'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
+        'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
+        'See https://ember-engines.com/docs/links for more info.',
+      !this._isEngine || this._engineMountPoint !== undefined
+    );
+  },
+  
   _isEngine: computed(function (this: any) {
     return getEngineParent(getOwner(this) as EngineInstance) !== undefined;
   }),


### PR DESCRIPTION
Back in Ember 3.x, `assertLinkToOrigin` was added to Ember's LinkTo component (see [this PR](https://github.com/emberjs/ember.js/pull/19477), see [this issue for details](https://github.com/emberjs/ember.js/issues/19459)). It's necessary for ember-engine's [LinkToExternal](https://github.com/ember-engines/ember-engines/blob/4c3b2aec998be7fd1d61b55657d4714b59375f31/packages/ember-engines/addon/components/link-to-external.js#L33) to work correctly.

However, this method was lost when the original LinkTo was ported to this addon 😞 

cc @mikrostew