### PR TITLE
remove code that was using an non-existent export

### DIFF
--- a/addon/mixins/_target_action_support.js
+++ b/addon/mixins/_target_action_support.js
@@ -4,7 +4,6 @@
 @module ember
 */
 
-import { context } from '../components/_internals';
 import { get, computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
@@ -29,11 +28,7 @@ export default Mixin.create({
     let actionContext = get(this, 'actionContext');
 
     if (typeof actionContext === 'string') {
-      let value = get(this, actionContext);
-      if (value === undefined) {
-        value = get(context.lookup, actionContext);
-      }
-      return value;
+      return get(this, actionContext);
     } else {
       return actionContext;
     }


### PR DESCRIPTION
avoid runtime error if that code was ever to be hit
since the commented out code this used to reference is using global lookups which have been deprecated, this seems like the correct change to make

closes #18 