### PR TITLE
Ember >= 4.x compatibility (require ember-source 4.8+)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        ember-version: [ember-beta, ember-lts-3.28]
+        ember-version: [ember-beta, ember-lts-4.8]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Provides the legacy implementation of the `Checkbox`, `LinkComponent`,
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.20 or above
-* Ember CLI v3.20 or above
-* Node.js v12 or above
+* Ember.js v4.0 or above
+* Ember CLI v4.0 or above
+* Node.js v16 or above
 
 
 Installation

--- a/addon/mixins/text-support.js
+++ b/addon/mixins/text-support.js
@@ -2,8 +2,6 @@
 import { get, set } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import TargetActionSupport from './_target_action_support';
-import { deprecate } from '@ember/debug';
-import { SEND_ACTION } from '@ember/deprecated-features';
 import { MUTABLE_CELL } from '@ember/-internals/views';
 
 const KEY_EVENTS = {
@@ -319,24 +317,7 @@ function sendAction(eventName, view, event) {
 
   let value = view.value;
 
-  if (SEND_ACTION && typeof action === 'string') {
-    let message = `Passing actions to components as strings (like \`<Input @${eventName}="${action}" />\`) is deprecated. Please use closure actions instead (\`<Input @${eventName}={{action "${action}"}} />\`).`;
-
-    deprecate(message, false, {
-      id: 'ember-component.send-action',
-      until: '4.0.0',
-      url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
-      for: 'ember-source',
-      since: {
-        enabled: '3.4.0',
-      },
-    });
-
-    view.triggerAction({
-      action: action,
-      actionContext: [value, event],
-    });
-  } else if (typeof action === 'function') {
+  if (typeof action === 'function') {
     action(value, event);
   }
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,7 +36,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-            '@glint/template': '*',
           },
         },
       },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,10 +8,10 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
+        name: 'ember-lts-4.8',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-source': '~4.8.6',
           },
         },
       },
@@ -36,9 +36,12 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            '@glint/template': '*',
           },
         },
       },
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack": "^5.52.1"
   },
   "peerDependencies": {
-    "ember-source": ">= 4"
+    "ember-source": ">= 4.8"
   },
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^2.4.1",
     "@embroider/test-setup": "^1.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@glint/template": "^1.2.1",
     "@types/ember-qunit": "^5.0.0",
     "@types/ember-resolver": "^5.0.11",
     "@types/ember__application": "^4.0.0",
@@ -77,7 +79,6 @@
     "ember-cli-terser": "^4.0.2",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^6.2.2",
     "ember-qunit": "^5.1.4",
@@ -101,10 +102,10 @@
     "webpack": "^5.52.1"
   },
   "peerDependencies": {
-    "ember-source": "*"
+    "ember-source": ">= 4"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": ">= 16"
   },
   "ember": {
     "edition": "octane"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,13 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/string@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.1.1.tgz#0a5ac0d1e4925259e41d5c8d55ef616117d47ff0"
+  integrity sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+
 "@ember/test-helpers@^2.4.1":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.6.0.tgz#d687515c6ab49ba72717fc62046970ef4a72ea9c"
@@ -1205,6 +1212,11 @@
   integrity sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
+
+"@glint/template@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@glint/template/-/template-1.2.1.tgz#b17b2e490ad1826d45e7bec3b87149ca926600e3"
+  integrity sha512-rlYy/93fAhYjXmTchWcwCpPFMfrqBYEskzbDYawS2oz4DVwtf4fOITLKB0QddQMI7WUCjgXAiIGZqcNa/R4YeQ==
 
 "@handlebars/parser@^1.1.0":
   version "1.1.0"
@@ -4712,11 +4724,6 @@ ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
-
-ember-export-application-global@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
-  integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
 ember-load-initializers@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
motivation for this is that @ember/legacy-built-in-components is a peer dep for ember-engines for "ember-source": "^3.24.1 || 4",
in ember-source: 4 sendAction was [rightly cleaned up](https://github.com/emberjs/ember.js/commit/52a1384a0c8a4cff7cc87d018e19d31188b7507d) and the named export is no longer resolvable which can cause warnings at best and errors at worst (trying to run an ember-engine while using a LinkTo component on ember source 4.x)

with this PR I propose we close that gap by releasing a new major for @ember/legacy-built-in-components to be used with ember-source >= 4.x
