### PR TITLE
chore: remove unwanted peer on ember-source

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,6 @@
     "typescript": "^4.5.5",
     "webpack": "^5.52.1"
   },
-  "peerDependencies": {
-    "ember-source": ">= 4.8"
-  },
   "engines": {
     "node": ">= 16"
   },


### PR DESCRIPTION
this peer results in accidentally bringing multiple copies and isn't actually needed