### PR TITLE
Bump GitHub actions to make CI work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Volta
-        uses: volta-cli/action@v1
+        uses: volta-cli/action@v4
 
       - name: Node Modules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ci-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -47,13 +47,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Volta
-        uses: volta-cli/action@v1
+        uses: volta-cli/action@v4
 
       - name: Node Modules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ci-yarn-${{ matrix.ember-version }}-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
don't think it worth to bring CI to fully operation status with all the matrix/try scenarios passing as this addon should not be used more than sparingly if at all.